### PR TITLE
Reduce admin connections and test fixes

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -2,7 +2,9 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const regeneratorRuntime = "regenerator-runtime";
 import server from "./src/server/server";
+import { admin } from "./src/server/kafka/kafka";
 
 export default async () => {
   global.testServer = await server;
+  global.admin = await admin;
 };

--- a/jest-teardown.ts
+++ b/jest-teardown.ts
@@ -1,3 +1,4 @@
 export default async (globalConfig) => {
+  await global.admin.disconnect();
   await global.testServer.stop();
 };

--- a/src/server/graphql/datasources/brokerAdmin.ts
+++ b/src/server/graphql/datasources/brokerAdmin.ts
@@ -8,7 +8,6 @@ import { Cluster, Broker } from "../../../types/types";
 
 export async function getClusterInfo(): Promise<Cluster> {
   try {
-    await admin.connect();
     const info = await admin.describeCluster();
     const brokers: Broker[] = [];
     for (let i = 0; i < info.brokers.length; i++) {
@@ -26,7 +25,6 @@ export async function getClusterInfo(): Promise<Cluster> {
       )[0],
     };
 
-    await admin.disconnect();
     return cluster;
   } catch (error) {
     console.log(error);
@@ -35,7 +33,6 @@ export async function getClusterInfo(): Promise<Cluster> {
 
 export async function getSingleTopic(name: string) {
   try {
-    await admin.connect();
     const topic = await admin
       .fetchTopicMetadata({ topics: [name] })
       .then((topics) => topics.topics[0]);
@@ -48,7 +45,6 @@ export async function getSingleTopic(name: string) {
 
 export async function getAllTopics() {
   try {
-    await admin.connect();
     const names = await admin.listTopics();
     const topics = await admin.fetchTopicMetadata({ topics: names });
 

--- a/src/server/kafka/kafka.ts
+++ b/src/server/kafka/kafka.ts
@@ -12,4 +12,10 @@ admin.on(CONNECT, () =>
   console.log(`Kafka Admin Connected to ${process.env.KAKFA_BROKER}!`)
 );
 
+async function run() {
+  return await admin.connect();
+}
+
+run();
+
 export { admin };


### PR DESCRIPTION
- Has admin client connect to cluster on startup to reduce the need to reconnect
- Jest tear down file closes the admin client