### PR TITLE
Fixes to rate metrics and disk usage metrics

### DIFF
--- a/__test__/server.test.ts
+++ b/__test__/server.test.ts
@@ -226,8 +226,8 @@ describe("GraphQL Queries", () => {
       const result = await global.testServer.executeOperation({
         query: `query Broker($brokerId: Int!) {
           broker(brokerId: $brokerId) {
-              diskUsage {
-                diskUsage
+              JVMMemoryUsage {
+                JVMMemoryUsage
                 time
               }
             }
@@ -237,10 +237,10 @@ describe("GraphQL Queries", () => {
         },
       });
       expect(result.errors).toBeUndefined();
-      expect(result.data.broker).toHaveProperty("diskUsage");
-      expect(result.data.broker.diskUsage).toEqual(
+      expect(result.data.broker).toHaveProperty("JVMMemoryUsage");
+      expect(result.data.broker.JVMMemoryUsage).toEqual(
         expect.objectContaining({
-          diskUsage: expect.any(Number),
+          JVMMemoryUsage: expect.any(Number),
           time: expect.any(String),
         })
       );

--- a/src/client/models/queries.tsx
+++ b/src/client/models/queries.tsx
@@ -41,11 +41,11 @@ export const ALL_BROKER_CPU_USAGE = gql`
 `;
 
 export const ALL_BROKER_DISK_USAGE = gql`
-  query BrokersDiskUsage($start: String, $end: String, $step: String) {
+  query BrokersJVMMemoryUsage($start: String, $end: String, $step: String) {
     broker: brokers(start: $start, end: $end, step: $step) {
       brokerId
-      diskUsage: diskUsageOverTime {
-        diskUsage
+      JVMMemoryUsage: JVMMemoryUsageOverTime {
+        JVMMemoryUsage
         time
       }
     }

--- a/src/client/pages/Dashboard.tsx
+++ b/src/client/pages/Dashboard.tsx
@@ -57,7 +57,7 @@ function DashboardContent() {
             >
               <RealTimeLineChart
                 query={ALL_BROKER_DISK_USAGE}
-                metric="diskUsage"
+                metric="JVMMemoryUsage"
                 step="30s"
                 duration={5}
                 pollInterval={60}

--- a/src/server/graphql/datasources/prometheusAPI.ts
+++ b/src/server/graphql/datasources/prometheusAPI.ts
@@ -113,9 +113,9 @@ class PrometheusAPI extends RESTDataSource {
     try {
       if (!unixStart || !unixEnd || isNaN(unixStart) || isNaN(unixEnd))
         throw "Date input incorrect";
-      const query = `query=sum(kafka_server_brokertopicmetrics_bytesinpersec{topic!=""${
+      const query = `query=sum(rate(kafka_server_brokertopicmetrics_bytesinpersec{topic!=""${
         filter ? `,instance=~"${this.filter(filter)}"` : ""
-      }})by(topic)&start=${unixStart}&end=${unixEnd}&step=${step}`;
+      }}[${step}]))by(topic)&start=${unixStart}&end=${unixEnd}&step=${step}`;
       const result = await this.get(`api/v1/query_range?${query}`);
       const data = result.data.result;
 
@@ -136,9 +136,9 @@ class PrometheusAPI extends RESTDataSource {
     try {
       if (!unixStart || !unixEnd || isNaN(unixStart) || isNaN(unixEnd))
         throw "Date input incorrect";
-      const query = `query=sum(kafka_server_brokertopicmetrics_bytesoutpersec{topic!=""${
+      const query = `query=sum(rate(kafka_server_brokertopicmetrics_bytesoutpersec{topic!=""${
         filter ? `,instance=~"${this.filter(filter)}"` : ""
-      }})by(topic)&start=${unixStart}&end=${unixEnd}&step=${step}`;
+      }}[${step}]))by(topic)&start=${unixStart}&end=${unixEnd}&step=${step}`;
       const result = await this.get(`api/v1/query_range?${query}`);
       const data = result.data.result;
 

--- a/src/server/graphql/datasources/prometheusAPI.ts
+++ b/src/server/graphql/datasources/prometheusAPI.ts
@@ -76,27 +76,27 @@ class PrometheusAPI extends RESTDataSource {
     return this.formatResponse(data, "offlinePartitionCount");
   }
 
-  async getDiskUsage() {
+  async getJVMMemoryUsage() {
     const query =
-      'query=(sum(avg_over_time(jvm_memory_bytes_used{area="heap", job!="zookeeper"}[1m]))by(application,instance)/sum(avg_over_time(jvm_memory_bytes_max{area="heap", job!="zookeeper"}[1m]))by(application,instance))*100';
+      'query=(sum(avg_over_time(jvm_memory_bytes_used{area="heap", job!="zookeeper"}[1m]))by(application,instance)/sum(avg_over_time(jvm_memory_bytes_committed{area="heap", job!="zookeeper"}[1m]))by(application,instance))*100';
     const result = await this.get(`api/v1/query?${query}`);
     const data = result.data.result;
 
-    return this.formatResponse(data, "diskUsage");
+    return this.formatResponse(data, "JVMMemoryUsage");
   }
 
-  async getDiskUsageOverTime(start, end, step) {
+  async getJVMMemoryUsageOverTime(start, end, step) {
     const unixStart = Math.round(new Date(start).getTime() / 1000);
     const unixEnd = Math.round(new Date(end).getTime() / 1000);
 
     try {
       if (!unixStart || !unixEnd || isNaN(unixStart) || isNaN(unixEnd))
         throw "Date input incorrect";
-      const query = `query=(sum(avg_over_time(jvm_memory_bytes_used{area="heap", job!="zookeeper"}[1m]))by(application,instance)/sum(avg_over_time(jvm_memory_bytes_max{area="heap", job!="zookeeper"}[1m]))by(application,instance))*100&start=${unixStart}&end=${unixEnd}&step=${step}`;
+      const query = `query=(sum(avg_over_time(jvm_memory_bytes_used{area="heap", job!="zookeeper"}[${step}]))by(application,instance)/sum(avg_over_time(jvm_memory_bytes_max{area="heap", job!="zookeeper"}[${step}]))by(application,instance))*100&start=${unixStart}&end=${unixEnd}&step=${step}`;
       const result = await this.get(`api/v1/query_range?${query}`);
       const data = result.data.result;
 
-      return this.formatResponseSeries(data, "diskUsage");
+      return this.formatResponseSeries(data, "JVMMemoryUsage");
     } catch (error) {
       console.log(`Error occured for Disk Usage Query to Prometheus with:
        start: ${start}, 

--- a/src/server/graphql/resolvers.ts
+++ b/src/server/graphql/resolvers.ts
@@ -5,7 +5,7 @@ import {
   UnderReplicatedPartitions,
   Cluster,
   Count,
-  DiskUsage,
+  JVMMemoryUsage,
 } from "../../types/types";
 
 /**
@@ -99,22 +99,22 @@ const resolvers = {
       }
     },
 
-    diskUsageOverTime: async (
+    JVMMemoryUsageOverTime: async (
       parent,
       args,
       { dataSources }
     ): Promise<BrokerCpuUsage> => {
       try {
-        const totalBrokerDiskUsage =
-          await dataSources.prometheusAPI.getDiskUsageOverTime(
+        const totalBrokerJVMMemoryUsage =
+          await dataSources.prometheusAPI.getJVMMemoryUsageOverTime(
             parent.start,
             parent.end,
             parent.step
           );
-        const brokerDiskUsage = totalBrokerDiskUsage.filter(
+        const brokerJVMMemoryUsage = totalBrokerJVMMemoryUsage.filter(
           (elem) => elem.brokerId === parent.brokerId
         )[0];
-        return brokerDiskUsage.values;
+        return brokerJVMMemoryUsage.values;
       } catch (error) {
         console.log(
           `An error occured with Query Broker Disk Usage Over Time: ${error}`
@@ -122,14 +122,18 @@ const resolvers = {
       }
     },
 
-    diskUsage: async (parent, args, { dataSources }): Promise<DiskUsage> => {
+    JVMMemoryUsage: async (
+      parent,
+      args,
+      { dataSources }
+    ): Promise<JVMMemoryUsage> => {
       try {
-        const totalBrokerDiskUsage =
-          await dataSources.prometheusAPI.getDiskUsage();
-        const brokerDiskUsage = totalBrokerDiskUsage.filter(
+        const totalBrokerJVMMemoryUsage =
+          await dataSources.prometheusAPI.getJVMMemoryUsage();
+        const brokerJVMMemoryUsage = totalBrokerJVMMemoryUsage.filter(
           (elem) => elem.brokerId === parent.brokerId
         )[0];
-        return brokerDiskUsage;
+        return brokerJVMMemoryUsage;
       } catch (error) {
         console.log(
           `An error has occured with Query Broker Disk Usage: ${error}`

--- a/src/server/graphql/typeDefs.ts
+++ b/src/server/graphql/typeDefs.ts
@@ -15,9 +15,9 @@ export const typeDefs = gql`
     brokerHost: String!
     numberUnderReplicatedPartitions: UnderReplicatedPartitions
     cpuUsage: BrokerCpuUsage
-    diskUsage: DiskUsage
+    JVMMemoryUsage: JVMMemoryUsage
     cpuUsageOverTime: [BrokerCpuUsage]
-    diskUsageOverTime: [DiskUsage]
+    JVMMemoryUsageOverTime: [JVMMemoryUsage]
     produceTotalTimeMs: TotalTimeMs
     consumerTotalTimeMs: TotalTimeMs
     followerTotalTimeMs: TotalTimeMs
@@ -54,8 +54,8 @@ export const typeDefs = gql`
     metric: Float
   }
 
-  type DiskUsage {
-    diskUsage: Float!
+  type JVMMemoryUsage {
+    JVMMemoryUsage: Float!
     time: String
   }
 

--- a/src/server/graphql/typeDefs.ts
+++ b/src/server/graphql/typeDefs.ts
@@ -51,7 +51,7 @@ export const typeDefs = gql`
 
   type Metric {
     time: String
-    metric: Int
+    metric: Float
   }
 
   type DiskUsage {

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -25,8 +25,8 @@ export interface BrokerCpuUsage {
   time: string;
 }
 
-export interface DiskUsage extends Metric {
-  diskUsage: number;
+export interface JVMMemoryUsage extends Metric {
+  JVMMemoryUsage: number;
 }
 
 export interface Topic {


### PR DESCRIPTION
- Rename disk usage to JVMMemoryUsage to better reflect the metric
- Update the metric to divide used divided by committed to better reflect the total JVM memory that can be used
- Update bytes in/bytes out to rate before summing.