### PR TITLE
Issue#46

### DIFF
--- a/src/client/components/MetricsCard.tsx
+++ b/src/client/components/MetricsCard.tsx
@@ -31,7 +31,6 @@ const MetricsCard = ({
   if (query) {
     const { loading, data } = useQuery(query, { ...variables });
     value = loading ? "Loading..." : keySearch(data, searchingFor);
-    console.log("value", value);
     if (value === undefined) value = "This metric is not available.";
   }
 

--- a/src/client/components/MetricsCard.tsx
+++ b/src/client/components/MetricsCard.tsx
@@ -31,6 +31,8 @@ const MetricsCard = ({
   if (query) {
     const { loading, data } = useQuery(query, { ...variables });
     value = loading ? "Loading..." : keySearch(data, searchingFor);
+    console.log("value", value);
+    if (value === undefined) value = "This metric is not available.";
   }
 
   return (

--- a/src/client/components/RealTimeLineChart.tsx
+++ b/src/client/components/RealTimeLineChart.tsx
@@ -79,7 +79,7 @@ export default function RealTimeLineChart({
           };
           timeNow.current = new Date(variables.end);
           refetch({ ...variables }).then((result) => {
-            if (loaded.current) {
+            if (loaded.current && typeof data[resource] !== "undefined") {
               result.data[resource].forEach((series, index) => {
                 series[`${metric}`].forEach((point) => {
                   chart.data.datasets[index].data.push(point);

--- a/src/client/pages/Topics.tsx
+++ b/src/client/pages/Topics.tsx
@@ -158,11 +158,13 @@ const Topics = () => {
                   elevation={8}
                 >
                   <MetricsCard
-                    value={
-                      topicCardQuery.loading
-                        ? "Loading..."
-                        : topicCardQuery.data.cluster.underMinIsr.metric
-                    }
+                    query={TOPIC_PAGE_QUERY}
+                    searchingFor="metric"
+                    // value={
+                    //   topicCardQuery.loading
+                    //     ? "Loading..."
+                    //     : topicCardQuery.data.cluster.underMinIsr.metric
+                    // }
                     title="Total Under Min ISR"
                     description="Should be zero."
                   />

--- a/src/client/pages/Topics.tsx
+++ b/src/client/pages/Topics.tsx
@@ -160,11 +160,6 @@ const Topics = () => {
                   <MetricsCard
                     query={TOPIC_PAGE_QUERY}
                     searchingFor="metric"
-                    // value={
-                    //   topicCardQuery.loading
-                    //     ? "Loading..."
-                    //     : topicCardQuery.data.cluster.underMinIsr.metric
-                    // }
                     title="Total Under Min ISR"
                     description="Should be zero."
                   />


### PR DESCRIPTION
#46 

# What?
Addresses rendering of Topic page when connecting to a new cluster that does not have any topics. 

# Why? 
New users will think the tool is not working when they connect to a new Kafka cluster.

# How?
The underminISR metric card now accepts a query, rather than accepting the value passed as props. The MetricCard component has been refactored to display a generic message when a metric is unavailable (undefined). Additionally, the RealTimeLineChart does not create plotted data points if the time series data value is undefined.
